### PR TITLE
Remove redundant install of npm in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,5 @@ RUN apt-get update -y &&\
     curl -sL https://deb.nodesource.com/setup_10.x | bash &&\
     apt-get install nodejs -y &&\
     node -v &&\
-    apt-get -y install npm &&\
     npm -v &&\
     npm install -g serverless


### PR DESCRIPTION
The debsource script in the Dockerfile (deb.nodesource.com/setup_10.x)
installs Nodejs and a compatible version of NPM so one does not need to
install NPM again since that will be installed or upgraded
automatically.

Attempting to do so may try to install npm from another debian
repository which may be incompatible and fail as seen in this
case.

Task: LU-5093