### PR TITLE
Lu 5843 getting variables

### DIFF
--- a/serverless.sh
+++ b/serverless.sh
@@ -3,6 +3,7 @@
 # Serverless deployment
 
 cd enrichment-deploy-repository
+serverless plugin install --name serverless-pseudo-parameters
 serverless plugin install --name serverless-latest-layer-version
 echo Packaging serverless bundle...
 serverless package --package pkg

--- a/serverless.yml
+++ b/serverless.yml
@@ -3,8 +3,8 @@ service: es-enrichment-sg
 provider:
   name: aws
   deploymentBucket:
-    name: spp-results-sandbox-serverless
-  role: arn:aws:iam::${self:custom.accountId}:role/lambda_invoke_lambda
+    name: spp-results-${self:custom.environment}-serverless
+  role: arn:aws:iam::#{AWS::AccountId}:role/lambda_invoke_lambda
   vpc:
     securityGroupIds:
       - ${file(../json_outputs/security_groups_output.json):SecurityGroups.0.GroupId}
@@ -21,7 +21,7 @@ provider:
     lambda: true
 
 custom:
-  accountId: ${env:aws_account_id}
+  environment: ${env:ENVIRONMENT}
 
 functions:
   deploy-enrichment-wrangler:
@@ -33,13 +33,13 @@ functions:
       exclude:
         - ./**
     layers:
-      - arn:aws:lambda:eu-west-2:${self:custom.accountId}:layer:es_python_layer:latest
-      - arn:aws:lambda:eu-west-2:${self:custom.accountId}:layer:dev-es-common-functions:latest
+      - arn:aws:lambda:eu-west-2:#{AWS::AccountId}:layer:es_python_layer:latest
+      - arn:aws:lambda:eu-west-2:#{AWS::AccountId}:layer:dev-es-common-functions:latest
     tags:
       app: results
     environment:
       checkpoint: 1
-      bucket_name: spp-results-sandbox
+      bucket_name: spp-results-${self:custom.environment}
       identifier_column: responder_id
       method_name: es-enrichment-method
 
@@ -52,12 +52,13 @@ functions:
       exclude:
         - ./**
     layers:
-      - arn:aws:lambda:eu-west-2:${self:custom.accountId}:layer:es_python_layer:latest
-      - arn:aws:lambda:eu-west-2:${self:custom.accountId}:layer:dev-es-common-functions:latest
+      - arn:aws:lambda:eu-west-2:#{AWS::AccountId}:layer:es_python_layer:latest
+      - arn:aws:lambda:eu-west-2:#{AWS::AccountId}:layer:dev-es-common-functions:latest
     tags:
       app: results
     environment:
-      bucket_name: spp-results-sandbox
+      bucket_name: spp-results-${self:custom.environment}
 
 plugins:
   - serverless-latest-layer-version
+  - serverless-pseudo-parameters


### PR DESCRIPTION
This change is so that we dont pull variables out of secrets manager.
uses serverless-pseudo-parameters to get account id
AWS::Account id comes from the account being deployed to and populates when the deploy happens.

Environment and Environment type are passed in from environment variables in the pipeline.

Deployment bucket name now uses environment.(because sandbox bucket contains the word sandbox and integration bucket contains the word integration)

In step functions deploy, wranglers.json is now with the code.

All changes have been tested together in 'test-pipeline-without-secrets' in the new concourse.