### PR TITLE
Lu6147

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 
 # vscode
 .vscode
+.devcontainer/
 
 # Distribution / packaging
 .Python

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ example:
         ]
       }
     },
-    "marine_mismatch_check": "true",
+    "marine_mismatch_check": true,
     "period_column": "period",
     "identifier_column": "responder_id"
 }

--- a/enrichment_method.py
+++ b/enrichment_method.py
@@ -14,7 +14,7 @@ class RuntimeSchema(Schema):
     data = fields.Str(required=True)
     identifier_column = fields.Str(required=True)
     lookups = fields.Dict(required=True)
-    marine_mismatch_check = fields.Str(required=True)
+    marine_mismatch_check = fields.Boolean(required=True)
     period_column = fields.Str(required=True)
     run_id = fields.Str(required=True)
     survey_column = fields.Str(required=True)
@@ -155,7 +155,7 @@ def data_enrichment(data_df, marine_mismatch_check, survey_column, period_column
     Does the enrichment process by merging together several datasets. Checks for marine
     mismatch, unallocated county, and unallocated region are performed at this point.
     :param data_df: DataFrame of data to be enriched - dataframe
-    :param marine_mismatch_check: True/False - Should check be done  - String
+    :param marine_mismatch_check: True/False - Should check be done  - Boolean
     :param survey_column: Survey code value - String
     :param period_column: Column that holds period. (period) - String
     :param bucket_name: Name of the s3 bucket - String
@@ -186,7 +186,7 @@ def data_enrichment(data_df, marine_mismatch_check, survey_column, period_column
                                                        identifier_column)])
 
     # Do Marine mismatch check here.
-    if marine_mismatch_check == "true":
+    if marine_mismatch_check:
         marine_anomalies = marine_mismatch_detector(
             data_df,
             survey_column,

--- a/enrichment_wrangler.py
+++ b/enrichment_wrangler.py
@@ -21,7 +21,7 @@ class RuntimeSchema(Schema):
     location = fields.Str(required=True)
     out_file_name = fields.Str(required=True)
     outgoing_message_group_id = fields.Str(required=True)
-    marine_mismatch_check = fields.Str(required=True)
+    marine_mismatch_check = fields.Boolean(required=True)
     period_column = fields.Str(required=True)
     sns_topic_arn = fields.Str(required=True)
     queue_url = fields.Str(required=True)

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -188,9 +188,9 @@ def test_value_error(which_lambda, expected_message, assertion,
     "lookup_data,column_names,file_list,marine_check",
     [
         (lookups, ["county", "county_name"],
-         ["responder_county_lookup.json", "county_marine_lookup.json"], False),
+         ["responder_county_lookup.json", "county_marine_lookup.json"], True),
         (bricks_blocks_lookups, ["region"],
-         ["region_lookup.json"], True)
+         ["region_lookup.json"], False)
     ])
 @mock_s3
 def test_data_enrichment(lookup_data, column_names, file_list, marine_check):

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -48,7 +48,7 @@ method_runtime_variables = {
     "RuntimeVariables": {
         "data": None,
         "lookups": lookups,
-        "marine_mismatch_check": "true",
+        "marine_mismatch_check": True,
         "period_column": "period",
         "survey_column": "survey",
         "identifier_column": "responder_id",
@@ -65,7 +65,7 @@ wrangler_runtime_variables = {
             "survey_column": "survey",
             "run_id": "bob",
             "queue_url": "Earl",
-            "marine_mismatch_check": "true",
+            "marine_mismatch_check": True,
             "incoming_message_group_id": "test_group",
             "in_file_name": "test_wrangler_input",
             "out_file_name": "test_wrangler_output.json",


### PR DESCRIPTION
## Intro
This implements [LU6147: Marine Mismatch Check Marker](https://collaborate2.ons.gov.uk/jira/browse/LU-6147). The intention is to use the boolean values True and False, rather the the literal strings "true" or "false".

## Changes
* Altered the check to use a boolean
* Altered marshmallow schema to validate for a boolean value
* Updated tests and documentation to match
* Added .devcontainer/ directory to gitignore to ease future local debugging

## Config changes
* To make this compatible the values will have to be changed to their boolean equivalents in the configs. I'm doing that in sandbox to start with and the other environments after the discuss how configs are to be deployed.