### PR TITLE
WIP - Removing Unneeded SQS Queue

### DIFF
--- a/enrichment_wrangler.py
+++ b/enrichment_wrangler.py
@@ -31,14 +31,10 @@ class RuntimeSchema(Schema):
 
     lookups = fields.Dict(required=True)
     in_file_name = fields.Str(required=True)
-    incoming_message_group_id = fields.Str(required=True)
-    location = fields.Str(required=True)
     out_file_name = fields.Str(required=True)
-    outgoing_message_group_id = fields.Str(required=True)
     marine_mismatch_check = fields.Boolean(required=True)
     period_column = fields.Str(required=True)
     sns_topic_arn = fields.Str(required=True)
-    queue_url = fields.Str(required=True)
     survey_column = fields.Str(required=True)
 
 
@@ -79,25 +75,18 @@ def lambda_handler(event, context):
         # Runtime Variables.
         lookups = runtime_variables["lookups"]
         in_file_name = runtime_variables["in_file_name"]
-        incoming_message_group_id = runtime_variables["incoming_message_group_id"]
-        location = runtime_variables["location"]
         out_file_name = runtime_variables["out_file_name"]
-        outgoing_message_group_id = runtime_variables["outgoing_message_group_id"]
         marine_mismatch_check = runtime_variables["marine_mismatch_check"]
         period_column = runtime_variables["period_column"]
         sns_topic_arn = runtime_variables["sns_topic_arn"]
-        sqs_queue_url = runtime_variables["queue_url"]
         survey_column = runtime_variables["survey_column"]
 
         logger.info("Retrieved configuration variables.")
 
         # Set up client.
         lambda_client = boto3.client("lambda", region_name="eu-west-2")
-        sqs = boto3.client("sqs", region_name="eu-west-2")
-        data_df, receipt_handler = aws_functions.get_dataframe(sqs_queue_url, bucket_name,
-                                                               in_file_name,
-                                                               incoming_message_group_id,
-                                                               location)
+
+        data_df = aws_functions.read_dataframe_from_s3(bucket_name, in_file_name)
 
         logger.info("Retrieved data from s3")
         data_json = data_df.to_json(orient="records")
@@ -124,23 +113,21 @@ def lambda_handler(event, context):
         if not json_response["success"]:
             raise exception_classes.MethodFailure(json_response["error"])
 
-        aws_functions.save_data(bucket_name, out_file_name, json_response["data"],
-                                sqs_queue_url, outgoing_message_group_id, location)
+        aws_functions.save_to_s3(bucket_name, out_file_name, json_response["data"])
 
         logger.info("Successfully sent data to s3.")
 
         anomalies = json_response["anomalies"]
 
         if anomalies != "[]":
-            aws_functions.save_to_s3(bucket_name, "Anomalies", anomalies, location)
+            aws_functions.save_to_s3(bucket_name, "Anomalies", anomalies)
             have_anomalies = True
         else:
             have_anomalies = False
 
         aws_functions.send_sns_message_with_anomalies(checkpoint, have_anomalies,
                                                       sns_topic_arn, "Enrichment.")
-        if receipt_handler:
-            sqs.delete_message(QueueUrl=sqs_queue_url, ReceiptHandle=receipt_handler)
+
         logger.info("Successfully sent message to sns.")
 
     except Exception as e:

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -115,9 +115,7 @@ def test_general_error(which_lambda, which_runtime_variables,
 
 
 @mock_s3
-@mock.patch('enrichment_wrangler.aws_functions.get_dataframe',
-            side_effect=test_generic_library.replacement_get_dataframe)
-def test_incomplete_read_error(mock_s3_get):
+def test_incomplete_read_error():
     file_list = ["test_wrangler_input.json"]
 
     test_generic_library.incomplete_read_error(lambda_wrangler_function,
@@ -143,9 +141,7 @@ def test_key_error(which_lambda, which_environment_variables,
 
 
 @mock_s3
-@mock.patch('enrichment_wrangler.aws_functions.get_dataframe',
-            side_effect=test_generic_library.replacement_get_dataframe)
-def test_method_error(mock_s3_get):
+def test_method_error():
     file_list = ["test_wrangler_input.json"]
 
     test_generic_library.wrangler_method_error(lambda_wrangler_function,
@@ -325,9 +321,7 @@ def test_missing_column_detector():
 
 
 @mock_s3
-@mock.patch('enrichment_wrangler.aws_functions.get_dataframe',
-            side_effect=test_generic_library.replacement_get_dataframe)
-def test_wrangler_success_passed(mock_s3_get):
+def test_wrangler_success_passed():
     """
     Runs the wrangler function up to the method invoke.
     :param None
@@ -379,11 +373,9 @@ def test_wrangler_success_passed(mock_s3_get):
 
 
 @mock_s3
-@mock.patch('enrichment_wrangler.aws_functions.get_dataframe',
-            side_effect=test_generic_library.replacement_get_dataframe)
-@mock.patch('enrichment_wrangler.aws_functions.save_data',
-            side_effect=test_generic_library.replacement_save_data)
-def test_wrangler_success_returned(mock_s3_get, mock_s3_put):
+@mock.patch('enrichment_wrangler.aws_functions.save_to_s3',
+            side_effect=test_generic_library.replacement_save_to_s3)
+def test_wrangler_success_returned(mock_s3_put):
     """
     Runs the wrangler function after the method invoke.
     :param None

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -60,16 +60,12 @@ wrangler_runtime_variables = {
     "RuntimeVariables":
         {
             "lookups": lookups,
-            "location": "Here",
             "checkpoint": "999",
             "survey_column": "survey",
             "run_id": "bob",
-            "queue_url": "Earl",
             "marine_mismatch_check": True,
-            "incoming_message_group_id": "test_group",
             "in_file_name": "test_wrangler_input",
             "out_file_name": "test_wrangler_output.json",
-            "outgoing_message_group_id": "test_id",
             "sns_topic_arn": "fake_sns_arn",
             "period_column": "period"
         }


### PR DESCRIPTION
I've replaced the SQS queue get and save, alongside it related variables.
Location also was removed because it was added separately only due to the filenames also being used as SQS IDs. Instead config loader can now add this to the beginning of the filenames before we merge in button overrides.
e.g. A simple for x in filenames: filenames[x] = location + filenames[x]

No changes need to be made to es-functions as far as I am aware at this time.

Let me know any questions or suggestions you may have in regards to this.