### PR TITLE
added calls to send bpm status: beginning, end and on error

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -107,3 +107,4 @@ xmltodict==0.12.0
 yamllint==1.20.0
 zipp==0.5.1
 git+https://github.com/ONSdigital/es-functions.git
+#To trigger build again.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -107,4 +107,3 @@ xmltodict==0.12.0
 yamllint==1.20.0
 zipp==0.5.1
 git+https://github.com/ONSdigital/es-functions.git
-#To trigger build again.

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -66,7 +66,8 @@ wrangler_runtime_variables = {
             "in_file_name": "test_wrangler_input",
             "out_file_name": "test_wrangler_output.json",
             "sns_topic_arn": "fake_sns_arn",
-            "period_column": "period"
+            "period_column": "period",
+            "total_steps": "6"
         }
 }
 

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -58,6 +58,7 @@ method_runtime_variables = {
 wrangler_runtime_variables = {
     "RuntimeVariables":
         {
+            "bpm_queue_url": "fake_queue_url",
             "lookups": lookups,
             "survey_column": "survey",
             "run_id": "bob",


### PR DESCRIPTION
Sets the status message for the stage "IN PROGRESS" for beginning "DONE" for end and "ERROR" for error/failure.
Calls "send_bpm_status" function from the functions library passing the queue url from config with status message and the run_id and module name.
